### PR TITLE
[orchagent] Voq system ports implementation

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -658,8 +658,6 @@ void IntfMgr::doCfgVoqInbandInterfaceTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
 
-    string inband_type="";
-
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
     {
@@ -672,18 +670,6 @@ void IntfMgr::doCfgVoqInbandInterfaceTask(Consumer &consumer)
 
         if (keys.size() == 1)
         {
-            for (auto idx : data)
-            {
-                const auto &field = fvField(idx);
-                const auto &value = fvValue(idx);
-
-                if (field == "inband_type")
-                {
-                    inband_type = value;
-                }
-
-            }
-
             if(op == SET_COMMAND)
             {
                 //No further processing. Just push to orchagent

--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -684,26 +684,19 @@ void IntfMgr::doCfgVoqInbandInterfaceTask(Consumer &consumer)
 
             }
 
-            if(inband_type == "port")
+            if(op == SET_COMMAND)
             {
-                if(op == SET_COMMAND)
-                {
-                    //For "port" type inband interface no further processing is needed.
-                    m_appIntfTableProducer.set(alias, data);
-                    m_stateIntfTable.hset(alias, "vrf", "");
-                }
-                else if(op == DEL_COMMAND)
-                {
-                    if (!doIntfGeneralTask(keys, data, op))
-                    {
-                        it++;
-                        continue;
-                    }
-                }
+                //No further processing. Just push to orchagent
+                m_appIntfTableProducer.set(alias, data);
+                m_stateIntfTable.hset(alias, "vrf", "");
             }
-            else
+            else if(op == DEL_COMMAND)
             {
-                SWSS_LOG_ERROR("%s type Inband interface not supported! i/f: %s", inband_type.c_str(), kfvKey(t).c_str());
+                if (!doIntfGeneralTask(keys, data, op))
+                {
+                    it++;
+                    continue;
+                }
             }
         }
         else if (keys.size() == 2)

--- a/cfgmgr/intfmgr.h
+++ b/cfgmgr/intfmgr.h
@@ -30,7 +30,7 @@ private:
     bool doIntfGeneralTask(const std::vector<std::string>& keys, std::vector<FieldValueTuple> data, const std::string& op);
     bool doIntfAddrTask(const std::vector<std::string>& keys, const std::vector<FieldValueTuple>& data, const std::string& op);
     void doTask(Consumer &consumer);
-    
+    void doCfgVoqInbandInterfaceTask(Consumer &consumer);
     bool isIntfStateOk(const std::string &alias);
     bool isIntfCreated(const std::string &alias);
     bool isIntfChangeVrf(const std::string &alias, const std::string &vrfName);

--- a/cfgmgr/intfmgrd.cpp
+++ b/cfgmgr/intfmgrd.cpp
@@ -47,6 +47,7 @@ int main(int argc, char **argv)
             CFG_VLAN_INTF_TABLE_NAME,
             CFG_LOOPBACK_INTERFACE_TABLE_NAME,
             CFG_VLAN_SUB_INTF_TABLE_NAME,
+            CFG_VOQ_INBAND_INTERFACE_TABLE_NAME,
         };
 
         DBConnector cfgDb("CONFIG_DB", 0);

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -1328,8 +1328,13 @@ bool IntfsOrch::voqSyncAddIntf(string &alias, sai_object_id_t &rif_id)
         {
             return true;
         }
+	alias = port.m_system_port_info.alias;
     }
-    alias = port.m_system_port_info.alias;
+    else
+    {
+        SWSS_LOG_ERROR("Port does not exist for %s!", alias.c_str());
+        return false;
+    }
 
     //Get router interface to make sure it exists
     sai_attribute_t attr;
@@ -1372,8 +1377,13 @@ bool IntfsOrch::voqSyncDelIntf(string &alias)
         {
             return true;
         }
+	alias = port.m_system_port_info.alias;
     }
-    alias = port.m_system_port_info.alias;
+    else
+    {
+        SWSS_LOG_ERROR("Port does not exist for %s!", alias.c_str());
+        return false;
+    }
 
     m_tableVoqSystemInterfaceTable.del(alias);
 

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -440,11 +440,8 @@ bool IntfsOrch::setIntf(const string& alias, sai_object_id_t vrf_id, const IpPre
 
     if(alias == gPortsOrch->m_inbandPortName)
     {
+        //Need to sync the inband intf neighbor for other asics
         gNeighOrch->addInbandNeighbor(alias, ip_prefix->getIp());
-
-        //There is no config to bring inband host if admin up. So bring the
-        //admin up here after setting the Ip2me route for inband host if ip
-        gPortsOrch->setSystemPortHostIfAdminUp(alias);
     }
 
     if (port.m_type == Port::VLAN)
@@ -700,6 +697,16 @@ void IntfsOrch::doTask(Consumer &consumer)
                 continue;
             }
 
+            //Voq Inband interface config processing
+            if(inband_type.size() && !ip_prefix_in_key)
+            {
+                if(!gPortsOrch->setVoqInbandIntf(alias, inband_type))
+                {
+                    it++;
+                    continue;
+                }
+            }
+
             Port port;
             if (!gPortsOrch->getPort(alias, port))
             {
@@ -717,11 +724,6 @@ void IntfsOrch::doTask(Consumer &consumer)
                     it++;
                     continue;
                 }
-            }
-
-            if(inband_type == "port")
-            {
-                gPortsOrch->voqAddInbandHostIf(alias, port);
             }
 
             if (m_vnetInfses.find(alias) != m_vnetInfses.end())

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -16,6 +16,7 @@
 #include "bufferorch.h"
 #include "directory.h"
 #include "vnetorch.h"
+#include "subscriberstatetable.h"
 
 extern sai_object_id_t gVirtualRouterId;
 extern Directory<Orch*> gDirectory;
@@ -32,6 +33,7 @@ extern RouteOrch *gRouteOrch;
 extern CrmOrch *gCrmOrch;
 extern BufferOrch *gBufferOrch;
 extern bool gIsNatSupported;
+extern NeighOrch *gNeighOrch;
 
 const int intfsorch_pri = 35;
 
@@ -52,8 +54,9 @@ static const vector<sai_router_interface_stat_t> rifStatIds =
     SAI_ROUTER_INTERFACE_STAT_OUT_ERROR_OCTETS,
 };
 
-IntfsOrch::IntfsOrch(DBConnector *db, string tableName, VRFOrch *vrf_orch) :
-        Orch(db, tableName, intfsorch_pri), m_vrfOrch(vrf_orch)
+IntfsOrch::IntfsOrch(DBConnector *db, string tableName, VRFOrch *vrf_orch, DBConnector *voqDb) :
+        Orch(db, tableName, intfsorch_pri), m_vrfOrch(vrf_orch),
+        m_tableVoqSystemInterfaceTable(voqDb, VOQ_SYSTEM_INTERFACE_TABLE_NAME)
 {
     SWSS_LOG_ENTER();
 
@@ -96,6 +99,11 @@ IntfsOrch::IntfsOrch(DBConnector *db, string tableName, VRFOrch *vrf_orch) :
     {
         SWSS_LOG_WARN("RIF flex counter group plugins was not set successfully: %s", e.what());
     }
+
+    //Add subscriber to process VOQ system interface
+    tableName = VOQ_SYSTEM_INTERFACE_TABLE_NAME;
+    Orch::addExecutor(new Consumer(new SubscriberStateTable(voqDb, tableName, TableConsumable::DEFAULT_POP_BATCH_SIZE, 0), this, tableName));
+
 }
 
 sai_object_id_t IntfsOrch::getRouterIntfsId(const string &alias)
@@ -430,6 +438,15 @@ bool IntfsOrch::setIntf(const string& alias, sai_object_id_t vrf_id, const IpPre
 
     addIp2MeRoute(port.m_vr_id, *ip_prefix);
 
+    if(alias == gPortsOrch->m_inbandPortName)
+    {
+        gNeighOrch->addInbandNeighbor(alias, ip_prefix->getIp());
+
+        //There is no config to bring inband host if admin up. So bring the
+        //admin up here after setting the Ip2me route for inband host if ip
+        gPortsOrch->setSystemPortHostIfAdminUp(alias);
+    }
+
     if (port.m_type == Port::VLAN)
     {
         addDirectedBroadcast(port, *ip_prefix);
@@ -452,6 +469,11 @@ bool IntfsOrch::removeIntf(const string& alias, sai_object_id_t vrf_id, const Ip
     if (ip_prefix && m_syncdIntfses[alias].ip_addresses.count(*ip_prefix))
     {
         removeIp2MeRoute(port.m_vr_id, *ip_prefix);
+
+        if(alias == gPortsOrch->m_inbandPortName)
+        {
+            gNeighOrch->delInbandNeighbor(alias, ip_prefix->getIp());
+        }
 
         if(port.m_type == Port::VLAN)
         {
@@ -497,6 +519,8 @@ void IntfsOrch::doTask(Consumer &consumer)
         return;
     }
 
+    string table_name = consumer.getTableName();
+
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
     {
@@ -521,6 +545,16 @@ void IntfsOrch::doTask(Consumer &consumer)
             ip_prefix_in_key = true;
         }
 
+        if(table_name == VOQ_SYSTEM_INTERFACE_TABLE_NAME)
+        {
+            if(!isRemoteSystemPortIntf(alias))
+            {
+                //Synced local interface. Skip
+                it = consumer.m_toSync.erase(it);
+                continue;
+            }
+        }
+
         const vector<FieldValueTuple>& data = kfvFieldsValues(t);
         string vrf_name = "", vnet_name = "", nat_zone = "";
         MacAddress mac;
@@ -529,6 +563,7 @@ void IntfsOrch::doTask(Consumer &consumer)
         bool adminUp;
         uint32_t nat_zone_id = 0;
         string proxy_arp = "";
+        string inband_type = "";
 
         for (auto idx : data)
         {
@@ -608,6 +643,10 @@ void IntfsOrch::doTask(Consumer &consumer)
             {
                 proxy_arp = value;
             }
+            else if (field == "inband_type")
+            {
+                inband_type = value;
+            }
         }
 
         if (alias == "eth0" || alias == "docker0")
@@ -678,6 +717,11 @@ void IntfsOrch::doTask(Consumer &consumer)
                     it++;
                     continue;
                 }
+            }
+
+            if(inband_type == "port")
+            {
+                gPortsOrch->voqAddInbandHostIf(alias, port);
             }
 
             if (m_vnetInfses.find(alias) != m_vnetInfses.end())
@@ -892,6 +936,7 @@ bool IntfsOrch::addRouterIntfs(sai_object_id_t vrf_id, Port &port)
     {
         case Port::PHY:
         case Port::LAG:
+        case Port::SYSTEM:
             attr.value.s32 = SAI_ROUTER_INTERFACE_TYPE_PORT;
             attrs.push_back(attr);
             break;
@@ -911,6 +956,7 @@ bool IntfsOrch::addRouterIntfs(sai_object_id_t vrf_id, Port &port)
     switch(port.m_type)
     {
         case Port::PHY:
+        case Port::SYSTEM:
             attr.id = SAI_ROUTER_INTERFACE_ATTR_PORT_ID;
             attr.value.oid = port.m_port_id;
             attrs.push_back(attr);
@@ -975,6 +1021,9 @@ bool IntfsOrch::addRouterIntfs(sai_object_id_t vrf_id, Port &port)
 
     SWSS_LOG_NOTICE("Create router interface %s MTU %u", port.m_alias.c_str(), port.m_mtu);
 
+    //Sync the interface to add to the SYSTEM_INTERFACE table of VOQ DB
+    voqSyncAddIntf(port.m_alias, port.m_rif_id);
+
     return true;
 }
 
@@ -1004,6 +1053,9 @@ bool IntfsOrch::removeRouterIntfs(Port &port)
     gPortsOrch->setPort(port.m_alias, port);
 
     SWSS_LOG_NOTICE("Remove router interface for port %s", port.m_alias.c_str());
+
+    //Sync the interface to del from the SYSTEM_INTERFACE table of VOQ DB
+    voqSyncDelIntf(port.m_alias);
 
     return true;
 }
@@ -1227,6 +1279,7 @@ void IntfsOrch::doTask(SelectableTimer &timer)
         {
             case Port::PHY:
             case Port::LAG:
+            case Port::SYSTEM:
                 type = "SAI_ROUTER_INTERFACE_TYPE_PORT";
                 break;
             case Port::VLAN:
@@ -1252,3 +1305,78 @@ void IntfsOrch::doTask(SelectableTimer &timer)
         }
     }
 }
+
+bool IntfsOrch::isRemoteSystemPortIntf(string alias)
+{
+    Port port;
+    if(gPortsOrch->getPort(alias, port))
+    {
+        return(port.m_system_port_info.type == SAI_SYSTEM_PORT_TYPE_REMOTE);
+    }
+    //Given alias is system port alias of the local port
+    return false;
+}
+
+bool IntfsOrch::voqSyncAddIntf(string &alias, sai_object_id_t &rif_id)
+{
+    //Sync only local interface. Confirm for the local interface and
+    //get the system port alias for key for syncing
+    Port port;
+    if(gPortsOrch->getPort(alias, port))
+    {
+        if(port.m_system_port_info.type == SAI_SYSTEM_PORT_TYPE_REMOTE)
+        {
+            return true;
+        }
+    }
+    alias = port.m_system_port_info.alias;
+
+    //Get router interface to make sure it exists
+    sai_attribute_t attr;
+    sai_status_t status;
+
+    attr.id = SAI_ROUTER_INTERFACE_ATTR_PORT_ID;
+
+    status = sai_router_intfs_api->get_router_interface_attribute(rif_id, 1, &attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to get rif for %s:0x%lx, rv:%d", alias.c_str(), rif_id, status);
+        return false;
+    }
+
+    //Get the Real ID of the RIF ID
+    string value;
+    const auto id = sai_serialize_object_id(rif_id);
+
+    if (m_vidToRidTable->hget("", id, value))
+    {
+        FieldValueTuple rifIdFv ("rif_id", value);
+        vector<FieldValueTuple> attrs;
+        attrs.push_back(rifIdFv);
+
+        m_tableVoqSystemInterfaceTable.set(alias, attrs);
+        return true;
+    }
+    SWSS_LOG_ERROR("Failed to get real ID from ASIC DB for RIF id 0x%lx of %s", rif_id, alias.c_str());
+    return false;
+}
+
+bool IntfsOrch::voqSyncDelIntf(string &alias)
+{
+    //Sync only local interface. Confirm for the local interface and
+    //get the system port alias for key for syncing to global VOQ DB
+    Port port;
+    if(gPortsOrch->getPort(alias, port))
+    {
+        if(port.m_system_port_info.type == SAI_SYSTEM_PORT_TYPE_REMOTE)
+        {
+            return true;
+        }
+    }
+    alias = port.m_system_port_info.alias;
+
+    m_tableVoqSystemInterfaceTable.del(alias);
+
+    return true;
+}
+

--- a/orchagent/intfsorch.h
+++ b/orchagent/intfsorch.h
@@ -32,7 +32,7 @@ typedef map<string, IntfsEntry> IntfsTable;
 class IntfsOrch : public Orch
 {
 public:
-    IntfsOrch(DBConnector *db, string tableName, VRFOrch *vrf_orch);
+    IntfsOrch(DBConnector *db, string tableName, VRFOrch *vrf_orch, DBConnector *voqDb);
 
     sai_object_id_t getRouterIntfsId(const string&);
     bool isPrefixSubnet(const IpPrefix&, const string&);
@@ -64,6 +64,8 @@ public:
 
     bool updateSyncdIntfPfx(const string &alias, const IpPrefix &ip_prefix, bool add = true);
 
+    bool isRemoteSystemPortIntf(string alias);
+
 private:
 
     SelectableTimer* m_updateMapsTimer = nullptr;
@@ -94,6 +96,11 @@ private:
 
     bool setIntfVlanFloodType(const Port &port, sai_vlan_flood_control_type_t vlan_flood_type);
     bool setIntfProxyArp(const string &alias, const string &proxy_arp);
+
+    Table m_tableVoqSystemInterfaceTable;
+    bool voqSyncAddIntf(string &alias, sai_object_id_t &rif_id);
+    bool voqSyncDelIntf(string &alias);
+
 };
 
 #endif /* SWSS_INTFSORCH_H */

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -817,130 +817,20 @@ void NeighOrch::doVoqSystemNeighTask(Consumer &consumer)
 
 bool NeighOrch::addInbandNeighbor(string alias, IpAddress ip_address)
 {
-    //Add neighbor record in SAI without adding host route for local inband to avoid route
-    //looping for packets destined to the Inband interface if the Inband is port type
+    //For "port" type inband, the inband reachability info syncing can be done through static
+    //configureation or VOQ_DB sync (this function)
 
-    if(gIntfsOrch->isRemoteSystemPortIntf(alias))
-    {
-        //Remote Inband interface. Skip
-        return true;
-    }
+    //For "vlan" type inband, the inband reachability info syncinng can be ARP learning of other
+    //asics inband or static configuration or through VOQ_DB sync (this function)
 
-    sai_status_t status;
-    MacAddress inband_mac = gMacAddress;
-
-    sai_object_id_t rif_id = gIntfsOrch->getRouterIntfsId(alias);
-    if (rif_id == SAI_NULL_OBJECT_ID)
-    {
-        SWSS_LOG_INFO("Failed to get rif_id for %s", alias.c_str());
-        return false;
-    }
-
-    //Make the object key
-    sai_neighbor_entry_t neighbor_entry;
-    neighbor_entry.rif_id = rif_id;
-    neighbor_entry.switch_id = gSwitchId;
-    copy(neighbor_entry.ip_address, ip_address);
-
-    vector<sai_attribute_t> neighbor_attrs;
-    sai_attribute_t attr;
-    attr.id = SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS;
-    memcpy(attr.value.mac, inband_mac.getMac(), 6);
-    neighbor_attrs.push_back(attr);
-
-    if(!addVoqEncapIndex(alias, ip_address, neighbor_attrs))
-    {
-        return false;
-    }
-
-    //No host route for neighbor of the Inband IP address
-    attr.id = SAI_NEIGHBOR_ENTRY_ATTR_NO_HOST_ROUTE;
-    attr.value.booldata = true;
-    neighbor_attrs.push_back(attr);
-
-    status = sai_neighbor_api->create_neighbor_entry(&neighbor_entry, static_cast<uint32_t>(neighbor_attrs.size()), neighbor_attrs.data());
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        if (status == SAI_STATUS_ITEM_ALREADY_EXISTS)
-        {
-            SWSS_LOG_ERROR("Entry exists: neighbor %s on %s, rv:%d", inband_mac.to_string().c_str(), alias.c_str(), status);
-            return true;
-        }
-        else
-        {
-            SWSS_LOG_ERROR("Failed to create neighbor %s on %s, rv:%d", inband_mac.to_string().c_str(), alias.c_str(), status);
-            return false;
-        }
-    }
-
-    SWSS_LOG_NOTICE("Created inband neighbor %s on %s", inband_mac.to_string().c_str(), alias.c_str());
-
-    gIntfsOrch->increaseRouterIntfsRefCount(alias);
-
-    if (neighbor_entry.ip_address.addr_family == SAI_IP_ADDR_FAMILY_IPV4)
-    {
-        gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_IPV4_NEIGHBOR);
-    }
-    else
-    {
-        gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_IPV6_NEIGHBOR);
-    }
-
-    //Sync the neighbor to add to the VOQ DB
-    voqSyncAddNeigh(alias, ip_address, inband_mac, neighbor_entry);
+    //May implement inband rechability info syncing through VOQ_DB sync here
 
     return true;
 }
 
 bool NeighOrch::delInbandNeighbor(string alias, IpAddress ip_address)
 {
-    //Remove neighbor from SAI
-    if(gIntfsOrch->isRemoteSystemPortIntf(alias))
-    {
-        //Remote Inband interface. Skip
-        return true;
-    }
-
-    MacAddress inband_mac = gMacAddress;
-
-    sai_object_id_t rif_id = gIntfsOrch->getRouterIntfsId(alias);
-
-    sai_neighbor_entry_t neighbor_entry;
-    neighbor_entry.rif_id = rif_id;
-    neighbor_entry.switch_id = gSwitchId;
-    copy(neighbor_entry.ip_address, ip_address);
-
-    sai_status_t status;
-    status = sai_neighbor_api->remove_neighbor_entry(&neighbor_entry);
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        if (status == SAI_STATUS_ITEM_NOT_FOUND)
-        {
-            SWSS_LOG_ERROR("Failed to locate neigbor %s on %s, rv:%d", inband_mac.to_string().c_str(), alias.c_str(), status);
-            return true;
-        }
-        else
-        {
-            SWSS_LOG_ERROR("Failed to remove neighbor %s on %s, rv:%d", inband_mac.to_string().c_str(), alias.c_str(), status);
-            return false;
-        }
-    }
-
-    if (neighbor_entry.ip_address.addr_family == SAI_IP_ADDR_FAMILY_IPV4)
-    {
-        gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_IPV4_NEIGHBOR);
-    }
-    else
-    {
-        gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_IPV6_NEIGHBOR);
-    }
-
-    SWSS_LOG_NOTICE("Removed neighbor %s on %s", inband_mac.to_string().c_str(), alias.c_str());
-
-    gIntfsOrch->decreaseRouterIntfsRefCount(alias);
-
-    //Sync the neighbor to delete from the VOQ DB
-    voqSyncDelNeigh(alias, ip_address);
+    //Remove inband rechability info sync
 
     return true;
 }

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -4,6 +4,8 @@
 #include "swssnet.h"
 #include "crmorch.h"
 #include "routeorch.h"
+#include "subscriberstatetable.h"
+#include "exec.h"
 
 extern sai_neighbor_api_t*         sai_neighbor_api;
 extern sai_next_hop_api_t*         sai_next_hop_api;
@@ -15,10 +17,15 @@ extern RouteOrch *gRouteOrch;
 
 const int neighorch_pri = 30;
 
-NeighOrch::NeighOrch(DBConnector *db, string tableName, IntfsOrch *intfsOrch) :
-        Orch(db, tableName, neighorch_pri), m_intfsOrch(intfsOrch)
+NeighOrch::NeighOrch(DBConnector *db, string tableName, IntfsOrch *intfsOrch, DBConnector *voqDb) :
+        Orch(db, tableName, neighorch_pri), m_intfsOrch(intfsOrch),
+        m_tableVoqSystemNeighTable(voqDb, VOQ_SYSTEM_NEIGH_TABLE_NAME)
 {
     SWSS_LOG_ENTER();
+
+    //Add subscriber to process VOQ system neigh
+    tableName = VOQ_SYSTEM_NEIGH_TABLE_NAME;
+    Orch::addExecutor(new Consumer(new SubscriberStateTable(voqDb, tableName, TableConsumable::DEFAULT_POP_BATCH_SIZE, 0), this, tableName));
 }
 
 bool NeighOrch::hasNextHop(const NextHopKey &nexthop)
@@ -39,6 +46,15 @@ bool NeighOrch::addNextHop(const IpAddress &ipAddress, const string &alias)
     }
 
     NextHopKey nexthop = { ipAddress, alias };
+    if(m_intfsOrch->isRemoteSystemPortIntf(alias))
+    {
+        //For remote system ports kernel nexthops are always on inband. Change the key
+        Port inbp;
+        if(gPortsOrch->getInbandPort(inbp))
+        {
+            nexthop.alias = inbp.m_alias;
+        }
+    }
     assert(!hasNextHop(nexthop));
     sai_object_id_t rif_id = m_intfsOrch->getRouterIntfsId(alias);
 
@@ -214,6 +230,16 @@ bool NeighOrch::removeNextHop(const IpAddress &ipAddress, const string &alias)
     SWSS_LOG_ENTER();
 
     NextHopKey nexthop = { ipAddress, alias };
+    if(m_intfsOrch->isRemoteSystemPortIntf(alias))
+    {
+        //For remote system ports kernel nexthops are always on inband. Change the key
+        Port inbp;
+        if(gPortsOrch->getInbandPort(inbp))
+        {
+            nexthop.alias = inbp.m_alias;
+        }
+    }
+
     assert(hasNextHop(nexthop));
 
     if (m_syncdNextHops[nexthop].ref_count > 0)
@@ -293,6 +319,13 @@ void NeighOrch::doTask(Consumer &consumer)
         return;
     }
 
+    string table_name = consumer.getTableName();
+    if(table_name == VOQ_SYSTEM_NEIGH_TABLE_NAME)
+    {
+        doVoqSystemNeighTask(consumer);
+        return;
+    }
+
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
     {
@@ -313,6 +346,14 @@ void NeighOrch::doTask(Consumer &consumer)
 
         if (alias == "eth0" || alias == "lo" || alias == "docker0")
         {
+            it = consumer.m_toSync.erase(it);
+            continue;
+        }
+
+        if(alias == gPortsOrch->m_inbandPortName)
+        {
+            //This is the neigh learned due to the kernel entry added on
+            //Inband interface for the remote system port neighbors. Skip
             it = consumer.m_toSync.erase(it);
             continue;
         }
@@ -408,7 +449,15 @@ bool NeighOrch::addNeighbor(const NeighborEntry &neighborEntry, const MacAddress
 
     if (m_syncdNeighbors.find(neighborEntry) == m_syncdNeighbors.end())
     {
-        status = sai_neighbor_api->create_neighbor_entry(&neighbor_entry, 1, &neighbor_attr);
+        vector<sai_attribute_t> neighbor_attrs;
+
+        neighbor_attrs.push_back(neighbor_attr);
+        if(!addVoqEncapIndex(alias, ip_address, neighbor_attrs))
+        {
+            return false;
+        }
+
+        status = sai_neighbor_api->create_neighbor_entry(&neighbor_entry, static_cast<uint32_t>(neighbor_attrs.size()), neighbor_attrs.data());
         if (status != SAI_STATUS_SUCCESS)
         {
             if (status == SAI_STATUS_ITEM_ALREADY_EXISTS)
@@ -478,6 +527,9 @@ bool NeighOrch::addNeighbor(const NeighborEntry &neighborEntry, const MacAddress
     NeighborUpdate update = { neighborEntry, macAddress, true };
     notify(SUBJECT_TYPE_NEIGH_CHANGE, static_cast<void *>(&update));
 
+    //Sync the neighbor to add to the VOQ DB
+    voqSyncAddNeigh(alias, ip_address, macAddress, neighbor_entry);
+
     return true;
 }
 
@@ -488,7 +540,17 @@ bool NeighOrch::removeNeighbor(const NeighborEntry &neighborEntry)
     sai_status_t status;
     IpAddress ip_address = neighborEntry.ip_address;
     string alias = neighborEntry.alias;
+
     NextHopKey nexthop = { ip_address, alias };
+    if(m_intfsOrch->isRemoteSystemPortIntf(alias))
+    {
+        //For remote system ports kernel nexthops are always on inband. Change the key
+        Port inbp;
+        if(gPortsOrch->getInbandPort(inbp))
+        {
+            nexthop.alias = inbp.m_alias;
+        }
+    }
 
     if (m_syncdNeighbors.find(neighborEntry) == m_syncdNeighbors.end())
     {
@@ -579,5 +641,535 @@ bool NeighOrch::removeNeighbor(const NeighborEntry &neighborEntry)
 
     removeNextHop(ip_address, alias);
 
+    //Sync the neighbor to delete from the VOQ DB
+    voqSyncDelNeigh(alias, ip_address);
+
+    return true;
+}
+
+void NeighOrch::doVoqSystemNeighTask(Consumer &consumer)
+{
+    SWSS_LOG_ENTER();
+
+    //Local inband port as the outgoing interface of the static neighbor and static route
+    Port port;
+    if(!gPortsOrch->getInbandPort(port))
+    {
+        //Inband port is not ready yet.
+        return;
+    }
+    string nbr_odev = port.m_alias;
+    MacAddress inband_mac = gMacAddress;
+
+    auto it = consumer.m_toSync.begin();
+    while (it != consumer.m_toSync.end())
+    {
+        KeyOpFieldsValuesTuple t = it->second;
+        string key = kfvKey(t);
+        string op = kfvOp(t);
+
+        size_t found = key.find(':');
+        if (found == string::npos)
+        {
+            SWSS_LOG_ERROR("Failed to parse key %s", key.c_str());
+            it = consumer.m_toSync.erase(it);
+            continue;
+        }
+
+        string alias = key.substr(0, found);
+
+        if(!gIntfsOrch->isRemoteSystemPortIntf(alias))
+        {
+            //Synced local neighbor. Skip
+            it = consumer.m_toSync.erase(it);
+            continue;
+        }
+
+        IpAddress ip_address(key.substr(found+1));
+
+        NeighborEntry neighbor_entry = { ip_address, alias };
+
+        if (op == SET_COMMAND)
+        {
+            Port p;
+            if (!gPortsOrch->getPort(alias, p))
+            {
+                SWSS_LOG_INFO("Port %s doesn't exist", alias.c_str());
+                it++;
+                continue;
+            }
+
+            if (!p.m_rif_id)
+            {
+                SWSS_LOG_INFO("Router interface doesn't exist on %s", alias.c_str());
+                it++;
+                continue;
+            }
+
+            MacAddress mac_address;
+            uint32_t encap_index = 0;
+            for (auto i = kfvFieldsValues(t).begin();
+                 i  != kfvFieldsValues(t).end(); i++)
+            {
+                if (fvField(*i) == "neigh")
+                    mac_address = MacAddress(fvValue(*i));
+
+                if(fvField(*i) == "encap_index")
+                {
+                    encap_index = (uint32_t)stoul(fvValue(*i));
+                }
+            }
+
+            if(!encap_index)
+            {
+                //Encap index is not available yet. Since this is remote neighbor, we need to wait till
+                //Encap index is made available either by dynamic syncing or by static config
+                it++;
+                continue;
+            }
+
+            if (m_syncdNeighbors.find(neighbor_entry) == m_syncdNeighbors.end() || m_syncdNeighbors[neighbor_entry] != mac_address)
+            {
+                if (!addKernelNeigh(nbr_odev, ip_address, inband_mac))
+                {
+                    SWSS_LOG_ERROR("Neigh entry add on dev %s failed for '%s'", nbr_odev.c_str(), kfvKey(t).c_str());
+                    it++;
+                    continue;
+                }
+                else
+                {
+                    SWSS_LOG_NOTICE("Neigh entry added on dev %s for '%s'", nbr_odev.c_str(), kfvKey(t).c_str());
+                }
+
+                if (!addKernelRoute(nbr_odev, ip_address))
+                {
+                    SWSS_LOG_ERROR("Route entry add on dev %s failed for '%s'", nbr_odev.c_str(), kfvKey(t).c_str());
+                    delKernelNeigh(nbr_odev, ip_address);
+                    it++;
+                    continue;
+                }
+                else
+                {
+                    SWSS_LOG_NOTICE("Route entry added on dev %s for '%s'", nbr_odev.c_str(), kfvKey(t).c_str());
+                }
+                SWSS_LOG_NOTICE("Added voq neighbor %s to kernel", kfvKey(t).c_str());
+
+                //Add neigh to SAI
+                if (addNeighbor(neighbor_entry, mac_address))
+                    it = consumer.m_toSync.erase(it);
+                else
+                {
+                    SWSS_LOG_ERROR("Failed to add voq neighbor %s to SAI", kfvKey(t).c_str());
+                    delKernelRoute(ip_address);
+                    delKernelNeigh(nbr_odev, ip_address);
+                    it++;
+                }
+            }
+            else
+                /* Duplicate entry */
+                it = consumer.m_toSync.erase(it);
+        }
+        else if (op == DEL_COMMAND)
+        {
+            if (m_syncdNeighbors.find(neighbor_entry) != m_syncdNeighbors.end())
+            {
+                if (!delKernelRoute(ip_address))
+                {
+                    SWSS_LOG_ERROR("Route entry on dev %s delete failed for '%s'", nbr_odev.c_str(), kfvKey(t).c_str());
+                }
+                else
+                {
+                    SWSS_LOG_NOTICE("Route entry on dev %s deleted for '%s'", nbr_odev.c_str(), kfvKey(t).c_str());
+                }
+
+                if (!delKernelNeigh(nbr_odev, ip_address))
+                {
+                    SWSS_LOG_ERROR("Neigh entry on dev %s delete failed for '%s'", nbr_odev.c_str(), kfvKey(t).c_str());
+                }
+                else
+                {
+                    SWSS_LOG_NOTICE("Neigh entry on dev %s deleted for '%s'", nbr_odev.c_str(), kfvKey(t).c_str());
+                }
+                SWSS_LOG_DEBUG("Deleted voq neighbor %s from kernel", kfvKey(t).c_str());
+
+                //Remove neigh from SAI
+                if (removeNeighbor(neighbor_entry))
+                {
+                    it = consumer.m_toSync.erase(it);
+                }
+                else
+                {
+                    SWSS_LOG_ERROR("Failed to remove voq neighbor %s from SAI", kfvKey(t).c_str());
+                    it++;
+                }
+            }
+            else
+                /* Cannot locate the neighbor */
+                it = consumer.m_toSync.erase(it);
+        }
+        else
+        {
+            SWSS_LOG_ERROR("Unknown operation type %s", op.c_str());
+            it = consumer.m_toSync.erase(it);
+        }
+    }
+}
+
+bool NeighOrch::addInbandNeighbor(string alias, IpAddress ip_address)
+{
+    //Add neighbor record in SAI without adding host route for local inband to avoid route
+    //looping for packets destined to the Inband interface if the Inband is port type
+
+    if(gIntfsOrch->isRemoteSystemPortIntf(alias))
+    {
+        //Remote Inband interface. Skip
+        return true;
+    }
+
+    sai_status_t status;
+    MacAddress inband_mac = gMacAddress;
+
+    sai_object_id_t rif_id = gIntfsOrch->getRouterIntfsId(alias);
+    if (rif_id == SAI_NULL_OBJECT_ID)
+    {
+        SWSS_LOG_INFO("Failed to get rif_id for %s", alias.c_str());
+        return false;
+    }
+
+    //Make the object key
+    sai_neighbor_entry_t neighbor_entry;
+    neighbor_entry.rif_id = rif_id;
+    neighbor_entry.switch_id = gSwitchId;
+    copy(neighbor_entry.ip_address, ip_address);
+
+    vector<sai_attribute_t> neighbor_attrs;
+    sai_attribute_t attr;
+    attr.id = SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS;
+    memcpy(attr.value.mac, inband_mac.getMac(), 6);
+    neighbor_attrs.push_back(attr);
+
+    if(!addVoqEncapIndex(alias, ip_address, neighbor_attrs))
+    {
+        return false;
+    }
+
+    //No host route for neighbor of the Inband IP address
+    attr.id = SAI_NEIGHBOR_ENTRY_ATTR_NO_HOST_ROUTE;
+    attr.value.booldata = true;
+    neighbor_attrs.push_back(attr);
+
+    status = sai_neighbor_api->create_neighbor_entry(&neighbor_entry, static_cast<uint32_t>(neighbor_attrs.size()), neighbor_attrs.data());
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        if (status == SAI_STATUS_ITEM_ALREADY_EXISTS)
+        {
+            SWSS_LOG_ERROR("Entry exists: neighbor %s on %s, rv:%d", inband_mac.to_string().c_str(), alias.c_str(), status);
+            return true;
+        }
+        else
+        {
+            SWSS_LOG_ERROR("Failed to create neighbor %s on %s, rv:%d", inband_mac.to_string().c_str(), alias.c_str(), status);
+            return false;
+        }
+    }
+
+    SWSS_LOG_NOTICE("Created inband neighbor %s on %s", inband_mac.to_string().c_str(), alias.c_str());
+
+    gIntfsOrch->increaseRouterIntfsRefCount(alias);
+
+    if (neighbor_entry.ip_address.addr_family == SAI_IP_ADDR_FAMILY_IPV4)
+    {
+        gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_IPV4_NEIGHBOR);
+    }
+    else
+    {
+        gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_IPV6_NEIGHBOR);
+    }
+
+    //Sync the neighbor to add to the VOQ DB
+    voqSyncAddNeigh(alias, ip_address, inband_mac, neighbor_entry);
+
+    return true;
+}
+
+bool NeighOrch::delInbandNeighbor(string alias, IpAddress ip_address)
+{
+    //Remove neighbor from SAI
+    if(gIntfsOrch->isRemoteSystemPortIntf(alias))
+    {
+        //Remote Inband interface. Skip
+        return true;
+    }
+
+    MacAddress inband_mac = gMacAddress;
+
+    sai_object_id_t rif_id = gIntfsOrch->getRouterIntfsId(alias);
+
+    sai_neighbor_entry_t neighbor_entry;
+    neighbor_entry.rif_id = rif_id;
+    neighbor_entry.switch_id = gSwitchId;
+    copy(neighbor_entry.ip_address, ip_address);
+
+    sai_status_t status;
+    status = sai_neighbor_api->remove_neighbor_entry(&neighbor_entry);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        if (status == SAI_STATUS_ITEM_NOT_FOUND)
+        {
+            SWSS_LOG_ERROR("Failed to locate neigbor %s on %s, rv:%d", inband_mac.to_string().c_str(), alias.c_str(), status);
+            return true;
+        }
+        else
+        {
+            SWSS_LOG_ERROR("Failed to remove neighbor %s on %s, rv:%d", inband_mac.to_string().c_str(), alias.c_str(), status);
+            return false;
+        }
+    }
+
+    if (neighbor_entry.ip_address.addr_family == SAI_IP_ADDR_FAMILY_IPV4)
+    {
+        gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_IPV4_NEIGHBOR);
+    }
+    else
+    {
+        gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_IPV6_NEIGHBOR);
+    }
+
+    SWSS_LOG_NOTICE("Removed neighbor %s on %s", inband_mac.to_string().c_str(), alias.c_str());
+
+    gIntfsOrch->decreaseRouterIntfsRefCount(alias);
+
+    //Sync the neighbor to delete from the VOQ DB
+    voqSyncDelNeigh(alias, ip_address);
+
+    return true;
+}
+
+bool NeighOrch::getSystemPortNeighEncapIndex(string alias, uint32_t &encap_index)
+{
+    string value;
+    if(m_tableVoqSystemNeighTable.hget(alias, "encap_index", value))
+    {
+        encap_index = (uint32_t) stoul(value);
+        return true;
+    }
+    return false;
+}
+
+bool NeighOrch::addVoqEncapIndex(string &alias, IpAddress &ip, vector<sai_attribute_t> &neighbor_attrs)
+{
+    sai_attribute_t attr;
+    uint32_t encap_index = 0;
+    string appKey = alias + ":" + ip.to_string();
+
+    if(getSystemPortNeighEncapIndex(appKey, encap_index))
+    {
+        attr.id = SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_INDEX;
+        attr.value.u32 = encap_index;
+        neighbor_attrs.push_back(attr);
+
+        attr.id = SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_IMPOSE_INDEX;
+        attr.value.booldata = true;
+        neighbor_attrs.push_back(attr);
+    }
+    else
+    {
+        //No Encap index available. Check if remote system port
+        if(gIntfsOrch->isRemoteSystemPortIntf(alias))
+        {
+            //Encap index not available and the interface is remote. Return false to re-try
+            SWSS_LOG_NOTICE("System port neighbor encap index is not available for remote neighbor %s. Re-try!", appKey.c_str());
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool NeighOrch::voqSyncAddNeigh(string &alias, IpAddress &ip_address, const MacAddress &mac, sai_neighbor_entry_t &neighbor_entry)
+{
+    sai_attribute_t attr;
+    sai_status_t status;
+
+    //Sync only local neigh. Confirm for the local neigh and
+    //get the system port alias for key for syncing to global VOQ DB
+    Port port;
+    if(gPortsOrch->getPort(alias, port))
+    {
+        if(port.m_system_port_info.type == SAI_SYSTEM_PORT_TYPE_REMOTE)
+        {
+            return true;
+        }
+    }
+    alias = port.m_system_port_info.alias;
+
+    attr.id = SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_INDEX;
+
+    status = sai_neighbor_api->get_neighbor_entry_attribute(&neighbor_entry, 1, &attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to get neighbor attribute for %s on %s, rv:%d", ip_address.to_string().c_str(), alias.c_str(), status);
+        return false;
+    }
+
+    vector<FieldValueTuple> attrs;
+
+    FieldValueTuple eiFv ("encap_index", to_string(attr.value.u32));
+    attrs.push_back(eiFv);
+
+    FieldValueTuple macFv ("neigh", mac.to_string());
+    attrs.push_back(macFv);
+
+    string key = alias + ":" + ip_address.to_string();
+    m_tableVoqSystemNeighTable.set(key, attrs);
+
+    return true;
+}
+
+bool NeighOrch::voqSyncDelNeigh(string &alias, IpAddress &ip_address)
+{
+    //Sync only local neigh. Confirm for the local neigh and
+    //get the system port alias for key for syncing to global VOQ DB
+    Port port;
+    if(gPortsOrch->getPort(alias, port))
+    {
+        if(port.m_system_port_info.type == SAI_SYSTEM_PORT_TYPE_REMOTE)
+        {
+            return true;
+        }
+    }
+    alias = port.m_system_port_info.alias;
+
+    string key = alias + ":" + ip_address.to_string();
+    m_tableVoqSystemNeighTable.del(key);
+
+    return true;
+}
+
+bool NeighOrch::addKernelRoute(string odev, IpAddress ip_addr)
+{
+    string cmd, res;
+
+    SWSS_LOG_ENTER();
+
+    string ip_str = ip_addr.to_string();
+
+    if(ip_addr.isV4())
+    {
+        cmd = "ip route add " + ip_str + "/32 dev " + odev;
+        SWSS_LOG_NOTICE("IPv4 Route Add cmd: %s",cmd.c_str());
+    }
+    else
+    {
+        cmd = "ip -6 route add " + ip_str + "/128 dev " + odev;
+        SWSS_LOG_NOTICE("IPv6 Route Add cmd: %s",cmd.c_str());
+    }
+
+    int32_t ret = swss::exec(cmd, res);
+
+    if(ret)
+    {
+        /* Just log error and return */
+        SWSS_LOG_ERROR("Failed to add route for %s, error: %d", ip_str.c_str(), ret);
+        return false;
+    }
+
+    SWSS_LOG_INFO("Added route for %s on device %s", ip_str.c_str(), odev.c_str());
+    return true;
+}
+
+bool NeighOrch::delKernelRoute(IpAddress ip_addr)
+{
+    string cmd, res;
+
+    SWSS_LOG_ENTER();
+
+    string ip_str = ip_addr.to_string();
+
+    if(ip_addr.isV4())
+    {
+        cmd = "ip route del " + ip_str + "/32";
+        SWSS_LOG_NOTICE("IPv4 Route Del cmd: %s",cmd.c_str());
+    }
+    else
+    {
+        cmd = "ip -6 route del " + ip_str + "/128";
+        SWSS_LOG_NOTICE("IPv6 Route Del cmd: %s",cmd.c_str());
+    }
+
+    int32_t ret = swss::exec(cmd, res);
+
+    if(ret)
+    {
+        /* Just log error and return */
+        SWSS_LOG_ERROR("Failed to delete route for %s, error: %d", ip_str.c_str(), ret);
+        return false;
+    }
+
+    SWSS_LOG_INFO("Deleted route for %s", ip_str.c_str());
+    return true;
+}
+
+bool NeighOrch::addKernelNeigh(string odev, IpAddress ip_addr, MacAddress mac_addr)
+{
+    SWSS_LOG_ENTER();
+
+    string cmd, res;
+    string ip_str = ip_addr.to_string();
+    string mac_str = mac_addr.to_string();
+
+    if(ip_addr.isV4())
+    {
+        cmd = "arp -s " + ip_str + " " + mac_str + " -i " + odev;
+        SWSS_LOG_NOTICE("IPv4 Nbr Add cmd: %s",cmd.c_str());
+    }
+    else
+    {
+        cmd = "ip -6 neigh add " + ip_str + " lladdr " + mac_str + " dev " + odev;
+        SWSS_LOG_NOTICE("IPv6 Nbr Add cmd: %s",cmd.c_str());
+    }
+
+    int32_t ret = swss::exec(cmd, res);
+
+    if(ret)
+    {
+        /* Just log error and return */
+        SWSS_LOG_ERROR("Failed to add Nbr for %s, error: %d", ip_str.c_str(), ret);
+        return false;
+    }
+
+    SWSS_LOG_INFO("Added Nbr for %s on interface %s", ip_str.c_str(), odev.c_str());
+    return true;
+}
+
+bool NeighOrch::delKernelNeigh(string odev, IpAddress ip_addr)
+{
+    string cmd, res;
+
+    SWSS_LOG_ENTER();
+
+    string ip_str = ip_addr.to_string();
+
+    if(ip_addr.isV4())
+    {
+        cmd = "arp -d " + ip_str + " -i " + odev;
+        SWSS_LOG_NOTICE("IPv4 Nbr Del cmd: %s",cmd.c_str());
+    }
+    else
+    {
+        cmd = "ip -6 neigh del " + ip_str + " dev " + odev;
+        SWSS_LOG_NOTICE("IPv4 Nbr Del cmd: %s",cmd.c_str());
+    }
+
+    int32_t ret = swss::exec(cmd, res);
+
+    if(ret)
+    {
+        /* Just log error and return */
+        SWSS_LOG_ERROR("Failed to delete Nbr for %s, error: %d", ip_str.c_str(), ret);
+        return false;
+    }
+
+    SWSS_LOG_INFO("Deleted Nbr for %s on interface %s", ip_str.c_str(), odev.c_str());
     return true;
 }

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -1000,8 +1000,13 @@ bool NeighOrch::voqSyncAddNeigh(string &alias, IpAddress &ip_address, const MacA
         {
             return true;
         }
+	alias = port.m_system_port_info.alias;
     }
-    alias = port.m_system_port_info.alias;
+    else
+    {
+        SWSS_LOG_ERROR("Port does not exist for %s!", alias.c_str());
+        return false;
+    }
 
     attr.id = SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_INDEX;
 
@@ -1037,8 +1042,13 @@ bool NeighOrch::voqSyncDelNeigh(string &alias, IpAddress &ip_address)
         {
             return true;
         }
+	alias = port.m_system_port_info.alias;
     }
-    alias = port.m_system_port_info.alias;
+    else
+    {
+        SWSS_LOG_ERROR("Port does not exist for %s!", alias.c_str());
+        return false;
+    }
 
     string key = alias + ":" + ip_address.to_string();
     m_tableVoqSystemNeighTable.del(key);

--- a/orchagent/neighorch.h
+++ b/orchagent/neighorch.h
@@ -35,7 +35,7 @@ struct NeighborUpdate
 class NeighOrch : public Orch, public Subject
 {
 public:
-    NeighOrch(DBConnector *db, string tableName, IntfsOrch *intfsOrch);
+    NeighOrch(DBConnector *db, string tableName, IntfsOrch *intfsOrch, DBConnector *voqDb);
 
     bool hasNextHop(const NextHopKey&);
 
@@ -51,6 +51,8 @@ public:
     bool ifChangeInformNextHop(const string &, bool);
     bool isNextHopFlagSet(const NextHopKey &, const uint32_t);
 
+    bool addInbandNeighbor(string alias, IpAddress ip_address);
+    bool delInbandNeighbor(string alias, IpAddress ip_address);
 private:
     IntfsOrch *m_intfsOrch;
 
@@ -67,6 +69,17 @@ private:
     bool clearNextHopFlag(const NextHopKey &, const uint32_t);
 
     void doTask(Consumer &consumer);
+    void doVoqSystemNeighTask(Consumer &consumer);
+
+    Table m_tableVoqSystemNeighTable;
+    bool getSystemPortNeighEncapIndex(string alias, uint32_t &encap_index);
+    bool addVoqEncapIndex(string &alias, IpAddress &ip, vector<sai_attribute_t> &neighbor_attrs);
+    bool addKernelRoute(string odev, IpAddress ip_addr);
+    bool delKernelRoute(IpAddress ip_addr);
+    bool addKernelNeigh(string odev, IpAddress ip_addr, MacAddress mac_addr);
+    bool delKernelNeigh(string odev, IpAddress ip_addr);
+    bool voqSyncAddNeigh(string &alias, IpAddress &ip_address, const MacAddress &mac, sai_neighbor_entry_t &neighbor_entry);
+    bool voqSyncDelNeigh(string &alias, IpAddress &ip_address);
 };
 
 #endif /* SWSS_NEIGHORCH_H */

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -557,7 +557,7 @@ bool Orch::parseIndexRange(const string &input, sai_uint32_t &range_low, sai_uin
 
 void Orch::addConsumer(DBConnector *db, string tableName, int pri)
 {
-    if (db->getDbName() == "CONFIG_DB" || db->getDbName() == "STATE_DB")
+    if (db->getDbName() == "CONFIG_DB" || db->getDbName() == "STATE_DB" || db->getDbName() == "VOQ_DB")
     {
         addExecutor(new Consumer(new SubscriberStateTable(db, tableName, TableConsumable::DEFAULT_POP_BATCH_SIZE, pri), this, tableName));
     }

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -28,6 +28,7 @@ const char comma               = ',';
 const char range_specifier     = '-';
 const char config_db_key_delimiter = '|';
 const char state_db_key_delimiter  = '|';
+const char voq_db_key_delimiter  = ':';
 
 #define INVM_PLATFORM_SUBSTRING "innovium"
 #define MLNX_PLATFORM_SUBSTRING "mellanox"

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -39,10 +39,11 @@ NatOrch *gNatOrch;
 
 bool gIsNatSupported = false;
 
-OrchDaemon::OrchDaemon(DBConnector *applDb, DBConnector *configDb, DBConnector *stateDb) :
+OrchDaemon::OrchDaemon(DBConnector *applDb, DBConnector *configDb, DBConnector *stateDb, DBConnector *voqDb) :
         m_applDb(applDb),
         m_configDb(configDb),
-        m_stateDb(stateDb)
+        m_stateDb(stateDb),
+        m_voqDb(voqDb)
 {
     SWSS_LOG_ENTER();
 }
@@ -123,8 +124,8 @@ bool OrchDaemon::init()
     ChassisOrch* chassis_frontend_orch = new ChassisOrch(m_configDb, m_applDb, chassis_frontend_tables, vnet_rt_orch);
     gDirectory.set(chassis_frontend_orch);
 
-    gIntfsOrch = new IntfsOrch(m_applDb, APP_INTF_TABLE_NAME, vrf_orch);
-    gNeighOrch = new NeighOrch(m_applDb, APP_NEIGH_TABLE_NAME, gIntfsOrch);
+    gIntfsOrch = new IntfsOrch(m_applDb, APP_INTF_TABLE_NAME, vrf_orch, m_voqDb);
+    gNeighOrch = new NeighOrch(m_applDb, APP_NEIGH_TABLE_NAME, gIntfsOrch, m_voqDb);
     gRouteOrch = new RouteOrch(m_applDb, APP_ROUTE_TABLE_NAME, gNeighOrch, gIntfsOrch, vrf_orch);
 
     TableConnector confDbSflowTable(m_configDb, CFG_SFLOW_TABLE_NAME);

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -37,7 +37,7 @@ using namespace swss;
 class OrchDaemon
 {
 public:
-    OrchDaemon(DBConnector *, DBConnector *, DBConnector *);
+    OrchDaemon(DBConnector *, DBConnector *, DBConnector *, DBConnector *);
     ~OrchDaemon();
 
     bool init();
@@ -51,6 +51,7 @@ private:
     DBConnector *m_applDb;
     DBConnector *m_configDb;
     DBConnector *m_stateDb;
+    DBConnector *m_voqDb;
 
     std::vector<Orch *> m_orchList;
     Select *m_select;

--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -36,6 +36,19 @@ struct VlanInfo
     sai_vlan_id_t       vlan_id = 0;
 };
 
+struct SystemPortInfo
+{
+    std::string alias = "";
+    sai_system_port_type_t type;
+    sai_object_id_t local_port_oid = 0;
+    uint32_t port_id = 0;
+    uint32_t switch_id = 0;
+    uint32_t core_index = 0;
+    uint32_t core_port_index = 0;
+    uint32_t speed = 400000;
+    uint32_t num_voq = 8;
+};
+
 class Port
 {
 public:
@@ -47,6 +60,7 @@ public:
         VLAN,
         LAG,
         SUBPORT,
+        SYSTEM,
         UNKNOWN
     } ;
 
@@ -114,6 +128,10 @@ public:
 
     std::unordered_set<sai_object_id_t> m_ingress_acl_tables_uset;
     std::unordered_set<sai_object_id_t> m_egress_acl_tables_uset;
+
+    sai_object_id_t  m_system_port_oid = 0;
+    SystemPortInfo   m_system_port_info;
+
 };
 
 }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4688,26 +4688,34 @@ bool PortsOrch::voqAddInbandHostIf(string &alias, Port &port)
 {
     if(m_inbandPortName == alias)
     {
-        //Hostif already created for this
-        SWSS_LOG_ERROR("Host interface %s already exists!", alias.c_str());
+        //Inband interface already exists with this name
+        SWSS_LOG_ERROR("Interface %s is already configured as inband!", alias.c_str());
         return true;
     }
 
-    if(!addHostIntfs(port, alias, port.m_hif_id))
+    if(!port.m_hif_id)
     {
-        SWSS_LOG_ERROR("Failed to create host interface for port %s", alias.c_str());
-        return false;
+        if(!addHostIntfs(port, alias, port.m_hif_id))
+        {
+            SWSS_LOG_ERROR("Failed to create host interface for port %s", alias.c_str());
+            return false;
+        }
+
+        if (!setHostIntfsOperStatus(port, true))
+        {
+            SWSS_LOG_ERROR("Failed to set operation status UP to host interface %s", alias.c_str());
+            return false;
+        }
+        SWSS_LOG_NOTICE("Added host if %" PRIx64 " for system port %s", port.m_hif_id, alias.c_str());
+    }
+    else
+    {
+        SWSS_LOG_NOTICE("Host interface already exists for port %s", alias.c_str());
     }
 
-    if (!setHostIntfsOperStatus(port, true))
-    {
-        SWSS_LOG_ERROR("Failed to set operation status UP to host interface %s", alias.c_str());
-        return false;
-    }
     //Store the name of the local inband port
     m_inbandPortName = alias;
 
-    SWSS_LOG_NOTICE("Added host if %" PRIx64 " for system port %s", port.m_hif_id, alias.c_str());
     return true;
 }
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4684,36 +4684,27 @@ bool PortsOrch::getInbandPort(Port &port)
     }
 }
 
-bool PortsOrch::voqAddInbandHostIf(string &alias, Port &port)
+bool PortsOrch::setVoqInbandIntf(string &alias, string &type)
 {
     if(m_inbandPortName == alias)
     {
         //Inband interface already exists with this name
-        SWSS_LOG_ERROR("Interface %s is already configured as inband!", alias.c_str());
+        SWSS_LOG_NOTICE("Interface %s is already configured as inband!", alias.c_str());
         return true;
     }
 
-    if(!port.m_hif_id)
+    Port port;
+    if(type == "port")
     {
-        if(!addHostIntfs(port, alias, port.m_hif_id))
+        if (!getPort(alias, port))
         {
-            SWSS_LOG_ERROR("Failed to create host interface for port %s", alias.c_str());
+            SWSS_LOG_NOTICE("Port configured for inband intf %s is not ready!", alias.c_str());
             return false;
         }
-
-        if (!setHostIntfsOperStatus(port, true))
-        {
-            SWSS_LOG_ERROR("Failed to set operation status UP to host interface %s", alias.c_str());
-            return false;
-        }
-        SWSS_LOG_NOTICE("Added host if %" PRIx64 " for system port %s", port.m_hif_id, alias.c_str());
     }
-    else
-    {
-        SWSS_LOG_NOTICE("Host interface already exists for port %s", alias.c_str());
-    }
+    // May do the processing for other inband type like type=vlan here
 
-    //Store the name of the local inband port
+    //Store the name of the inband interface
     m_inbandPortName = alias;
 
     return true;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -26,6 +26,7 @@
 #include "countercheckorch.h"
 #include "notifier.h"
 #include "redisclient.h"
+#include "exec.h"
 
 extern sai_switch_api_t *sai_switch_api;
 extern sai_bridge_api_t *sai_bridge_api;
@@ -41,6 +42,7 @@ extern IntfsOrch *gIntfsOrch;
 extern NeighOrch *gNeighOrch;
 extern CrmOrch *gCrmOrch;
 extern BufferOrch *gBufferOrch;
+extern sai_system_port_api_t *sai_system_port_api;
 
 #define VLAN_PREFIX         "Vlan"
 #define DEFAULT_VLAN_ID     1
@@ -359,6 +361,9 @@ PortsOrch::PortsOrch(DBConnector *db, vector<table_name_with_pri_t> &tableNames)
     m_default1QBridge = attrs[0].value.oid;
     m_defaultVlan = attrs[1].value.oid;
 
+    /* Get System ports */
+    getSystemPorts();
+
     removeDefaultVlanMembers();
     removeDefaultBridgePorts();
 
@@ -372,7 +377,7 @@ PortsOrch::PortsOrch(DBConnector *db, vector<table_name_with_pri_t> &tableNames)
 void PortsOrch::removeDefaultVlanMembers()
 {
     /* Get VLAN members in default VLAN */
-    vector<sai_object_id_t> vlan_member_list(m_portCount);
+    vector<sai_object_id_t> vlan_member_list(m_portCount + m_systemPortCount);
 
     sai_attribute_t attr;
     attr.id = SAI_VLAN_ATTR_MEMBER_LIST;
@@ -403,10 +408,10 @@ void PortsOrch::removeDefaultVlanMembers()
 void PortsOrch::removeDefaultBridgePorts()
 {
     /* Get bridge ports in default 1Q bridge
-     * By default, there will be m_portCount number of SAI_BRIDGE_PORT_TYPE_PORT
+     * By default, there will be (m_portCount + m_systemPortCount) number of SAI_BRIDGE_PORT_TYPE_PORT
      * ports and one SAI_BRIDGE_PORT_TYPE_1Q_ROUTER port. The former type of
      * ports will be removed. */
-    vector<sai_object_id_t> bridge_port_list(m_portCount + 1);
+    vector<sai_object_id_t> bridge_port_list(m_portCount + m_systemPortCount + 1);
 
     sai_attribute_t attr;
     attr.id = SAI_BRIDGE_ATTR_PORT_LIST;
@@ -543,6 +548,7 @@ bool PortsOrch::getPort(sai_object_id_t id, Port &port)
         switch (portIter.second.m_type)
         {
         case Port::PHY:
+        case Port::SYSTEM:
             if(portIter.second.m_port_id == id)
             {
                 port = portIter.second;
@@ -2027,6 +2033,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
              */
             if (!m_initDone)
             {
+                addSystemPorts();
                 m_initDone = true;
                 SWSS_LOG_INFO("Get PortInitDone notification from portsyncd.");
             }
@@ -4444,6 +4451,284 @@ bool PortsOrch::initGearboxPort(Port &port)
             m_gearboxPortListLaneMap[port.m_port_id] = make_tuple(systemPort, linePort);
         }
     }
+    return true;
+}
+
+bool PortsOrch::getSystemPorts()
+{
+    sai_status_t status;
+    sai_attribute_t attr;
+    uint32_t i;
+
+    m_systemPortCount = 0;
+
+    attr.id = SAI_SWITCH_ATTR_NUMBER_OF_SYSTEM_PORTS;
+
+    status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to get number of system ports, rv:%d", status);
+        return false;
+    }
+
+    m_systemPortCount = attr.value.u32;
+    SWSS_LOG_NOTICE("Got %d system ports", m_systemPortCount);
+
+    if(m_systemPortCount)
+    {
+        /* Make <switch_id, core, core port> tuple and system port oid map */
+
+        vector<sai_object_id_t> system_port_list;
+        system_port_list.resize(m_systemPortCount);
+
+        attr.id = SAI_SWITCH_ATTR_SYSTEM_PORT_LIST;
+        attr.value.objlist.count = (uint32_t)system_port_list.size();
+        attr.value.objlist.list = system_port_list.data();
+
+        status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to get system port list, rv:%d", status);
+            return false;
+        }
+
+        uint32_t spcnt = attr.value.objlist.count;
+        for(i = 0; i < spcnt; i++)
+        {
+            attr.id = SAI_SYSTEM_PORT_ATTR_CONFIG_INFO;
+
+            status = sai_system_port_api->get_system_port_attribute(system_port_list[i], 1, &attr);
+            if (status != SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_ERROR("Failed to get system port config info spid:%" PRIx64, system_port_list[i]);
+                return false;
+            }
+
+            SWSS_LOG_NOTICE("SystemPort(0x%lx) - port_id:%u, switch_id:%u, core:%u, core_port:%u, speed:%u, voqs:%u",
+                            system_port_list[i],
+                            attr.value.sysportconfig.port_id,
+                            attr.value.sysportconfig.attached_switch_id,
+                            attr.value.sysportconfig.attached_core_index,
+                            attr.value.sysportconfig.attached_core_port_index,
+                            attr.value.sysportconfig.speed,
+                            attr.value.sysportconfig.num_voq);
+
+            tuple<int, int, int> sp_key(attr.value.sysportconfig.attached_switch_id,
+                    attr.value.sysportconfig.attached_core_index,
+                    attr.value.sysportconfig.attached_core_port_index);
+
+            m_systemPortOidMap[sp_key] = system_port_list[i];
+        }
+    }
+
+    return true;
+}
+
+bool PortsOrch::addSystemPorts()
+{
+    vector<string> keys;
+    vector<FieldValueTuple> spFv;
+
+    DBConnector appDb(APPL_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
+    Table appSystemPortTable(&appDb, APP_SYSTEM_PORT_TABLE_NAME);
+
+    //Retrieve system port configurations from APP DB
+    appSystemPortTable.getKeys(keys);
+    for ( auto &alias : keys )
+    {
+        appSystemPortTable.get(alias, spFv);
+
+        int32_t system_port_id = -1;
+        int32_t switch_id = -1;
+        int32_t core_index = -1;
+        int32_t core_port_index = -1;
+        int32_t speed = -1;
+
+        for ( auto &fv : spFv )
+        {
+            if(fv.first == "switch_id")
+            {
+                switch_id = stoi(fv.second);
+                continue;
+            }
+            if(fv.first == "core_index")
+            {
+                core_index = stoi(fv.second);
+                continue;
+            }
+            if(fv.first == "core_port_index")
+            {
+                core_port_index = stoi(fv.second);
+                continue;
+            }
+            if(fv.first == "speed")
+            {
+                speed = stoi(fv.second);
+                continue;
+            }
+            if(fv.first == "system_port_id")
+            {
+                system_port_id = stoi(fv.second);
+                continue;
+            }
+        }
+
+        if(system_port_id < 0 || switch_id < 0 || core_index < 0 || core_port_index < 0)
+        {
+            SWSS_LOG_ERROR("Invalid or Missing field values for %s! system_port id:%d, switch_id:%d, core_index:%d, core_port_index:%d",
+                    alias.c_str(), system_port_id, switch_id, core_index, core_port_index);
+            continue;
+        }
+
+        if(speed < 0)
+        {
+            speed = 400000;
+        }
+
+        tuple<int, int, int> sp_key(switch_id, core_index, core_port_index);
+
+        if(m_systemPortOidMap.find(sp_key) != m_systemPortOidMap.end())
+        {
+
+            sai_attribute_t attr;
+            vector<sai_attribute_t> attrs;
+            sai_object_id_t system_port_oid;
+            sai_status_t status;
+
+            //Retrive system port config info and enable
+            system_port_oid = m_systemPortOidMap[sp_key];
+
+            attr.id = SAI_SYSTEM_PORT_ATTR_TYPE;
+            attrs.push_back(attr);
+
+            attr.id = SAI_SYSTEM_PORT_ATTR_CONFIG_INFO;
+            attrs.push_back(attr);
+
+            status = sai_system_port_api->get_system_port_attribute(system_port_oid, static_cast<uint32_t>(attrs.size()), attrs.data());
+            if (status != SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_ERROR("Failed to get system port config info spid:%" PRIx64, system_port_oid);
+                continue;
+            }
+
+            //Create or update system port and add to the port list.
+            Port port(alias, Port::SYSTEM);
+            port.m_port_id = system_port_oid;
+            port.m_admin_state_up = true;
+            port.m_oper_status = SAI_PORT_OPER_STATUS_UP;
+            port.m_speed = attrs[1].value.sysportconfig.speed;
+            if (attrs[0].value.s32 == SAI_SYSTEM_PORT_TYPE_LOCAL)
+            {
+                //Get the local port oid
+                attr.id = SAI_SYSTEM_PORT_ATTR_PORT;
+
+                status = sai_system_port_api->get_system_port_attribute(system_port_oid, 1, &attr);
+                if (status != SAI_STATUS_SUCCESS)
+                {
+                    SWSS_LOG_ERROR("Failed to get local port oid of local system port spid:%" PRIx64, system_port_oid);
+                    continue;
+                }
+
+                //System port for local port. Update the system port info in the existing physical port
+                if(!getPort(attr.value.oid, port))
+                {
+                    //This is system port for non-front panel local port (CPU or OLP or RCY (Inband)). Not an error
+                    SWSS_LOG_NOTICE("Add port for non-front panel local system port 0x%" PRIx64 "; core: %d, core port: %d",
+                            system_port_oid, core_index, core_port_index);
+                }
+                port.m_system_port_info.local_port_oid = attr.value.oid;
+            }
+
+            port.m_system_port_oid = system_port_oid;
+
+            port.m_system_port_info.alias = alias;
+            port.m_system_port_info.type = (sai_system_port_type_t) attrs[0].value.s32;
+            port.m_system_port_info.port_id = attrs[1].value.sysportconfig.port_id;
+            port.m_system_port_info.switch_id = attrs[1].value.sysportconfig.attached_switch_id;
+            port.m_system_port_info.core_index = attrs[1].value.sysportconfig.attached_core_index;
+            port.m_system_port_info.core_port_index = attrs[1].value.sysportconfig.attached_core_port_index;
+            port.m_system_port_info.speed = attrs[1].value.sysportconfig.speed;
+            port.m_system_port_info.num_voq = attrs[1].value.sysportconfig.num_voq;
+
+            setPort(port.m_alias, port);
+            if(m_port_ref_count.find(port.m_alias) == m_port_ref_count.end())
+            {
+                m_port_ref_count[port.m_alias] = 0;
+            }
+
+            SWSS_LOG_NOTICE("Added system port %" PRIx64 " for %s", system_port_oid, alias.c_str());
+        }
+        else
+        {
+            //System port does not exist in the switch
+            //This can not happen since all the system ports are supposed to be created during switch creation itself
+
+            SWSS_LOG_NOTICE("System port %s does not exist in switch. Port not added!", alias.c_str());
+            continue;
+        }
+    }
+
+    return true;
+}
+
+bool PortsOrch::getInbandPort(Port &port)
+{
+    if (m_portList.find(m_inbandPortName) == m_portList.end())
+    {
+        return false;
+    }
+    else
+    {
+        port = m_portList[m_inbandPortName];
+        return true;
+    }
+}
+
+bool PortsOrch::voqAddInbandHostIf(string &alias, Port &port)
+{
+    if(m_inbandPortName == alias)
+    {
+        //Hostif already created for this
+        SWSS_LOG_ERROR("Host interface %s already exists!", alias.c_str());
+        return true;
+    }
+
+    if(!addHostIntfs(port, alias, port.m_hif_id))
+    {
+        SWSS_LOG_ERROR("Failed to create host interface for port %s", alias.c_str());
+        return false;
+    }
+
+    if (!setHostIntfsOperStatus(port, true))
+    {
+        SWSS_LOG_ERROR("Failed to set operation status UP to host interface %s", alias.c_str());
+        return false;
+    }
+    //Store the name of the local inband port
+    m_inbandPortName = alias;
+
+    SWSS_LOG_NOTICE("Added host if %" PRIx64 " for system port %s", port.m_hif_id, alias.c_str());
+    return true;
+}
+
+bool PortsOrch::setSystemPortHostIfAdminUp(string alias)
+{
+    string cmd, res;
+
+    //Bring admin up system port
+    cmd = "ip link set dev " + alias + " up";
+
+    SWSS_LOG_NOTICE("Bring admin up %s: %s", alias.c_str(), cmd.c_str());
+
+    int32_t ret = swss::exec(cmd, res);
+
+    if(ret)
+    {
+        /* Just log error and return */
+        SWSS_LOG_ERROR("Failed to admin up %s", alias.c_str());
+        return false;
+    }
+
     return true;
 }
 

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -91,6 +91,7 @@ public:
     bool getPortByBridgePortId(sai_object_id_t bridge_port_id, Port &port);
     void setPort(string alias, Port port);
     void getCpuPort(Port &port);
+    bool getInbandPort(Port &port);
     bool getVlanByVlanId(sai_vlan_id_t vlan_id, Port &vlan);
     bool getAclBindPortId(string alias, sai_object_id_t &port_id);
 
@@ -126,6 +127,11 @@ public:
     bool addSubPort(Port &port, const string &alias, const bool &adminUp = true, const uint32_t &mtu = 0);
     bool removeSubPort(const string &alias);
     void getLagMember(Port &lag, vector<Port> &portv);
+
+    string m_inbandPortName = "";
+    bool voqAddInbandHostIf(string &alias, Port &port);
+    bool setSystemPortHostIfAdminUp(string alias);
+
 private:
     unique_ptr<Table> m_counterTable;
     unique_ptr<Table> m_counterLagTable;
@@ -275,6 +281,13 @@ private:
                                 sai_acl_bind_point_type_t &sai_acl_bind_type);
     void initGearbox();
     bool initGearboxPort(Port &port);
+
+    //map key is tuple of <attached_switch_id, core_index, core_port_index>
+    map<tuple<int, int, int>, sai_object_id_t> m_systemPortOidMap;
+    sai_uint32_t m_systemPortCount;
+    bool getSystemPorts();
+    bool addSystemPorts();
+
 };
 #endif /* SWSS_PORTSORCH_H */
 

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -129,7 +129,7 @@ public:
     void getLagMember(Port &lag, vector<Port> &portv);
 
     string m_inbandPortName = "";
-    bool voqAddInbandHostIf(string &alias, Port &port);
+    bool setVoqInbandIntf(string &alias, string &type);
     bool setSystemPortHostIfAdminUp(string alias);
 
 private:

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -1085,6 +1085,15 @@ bool RouteOrch::addRoute(RouteBulkContext& ctx, const NextHopGroupKey &nextHops)
         NextHopKey nexthop(nextHops.to_string());
         if (nexthop.ip_address.isZero())
         {
+            if(nexthop.alias == gPortsOrch->m_inbandPortName)
+            {
+                //This routes is the static route added for the remote system neighbors
+                //We do not need this route in the ASIC since the static neighbor creation
+                //in ASIC adds the same full mask route (host route) in ASIC automatically
+                //So skip.
+                return true;
+            }
+
             next_hop_id = m_intfsOrch->getRouterIntfsId(nexthop.alias);
             /* rif is not created yet */
             if (next_hop_id == SAI_NULL_OBJECT_ID)

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -51,6 +51,7 @@ sai_bmtor_api_t*            sai_bmtor_api;
 sai_samplepacket_api_t*     sai_samplepacket_api;
 sai_debug_counter_api_t*    sai_debug_counter_api;
 sai_nat_api_t*              sai_nat_api;
+sai_system_port_api_t*      sai_system_port_api;
 
 extern sai_object_id_t gSwitchId;
 extern bool gSairedisRecord;
@@ -170,6 +171,7 @@ void initSaiApi()
     sai_api_query(SAI_API_SAMPLEPACKET,         (void **)&sai_samplepacket_api);
     sai_api_query(SAI_API_DEBUG_COUNTER,        (void **)&sai_debug_counter_api);
     sai_api_query(SAI_API_NAT,                  (void **)&sai_nat_api);
+    sai_api_query(SAI_API_SYSTEM_PORT,          (void **)&sai_system_port_api);
 
     sai_log_set(SAI_API_SWITCH,                 SAI_LOG_LEVEL_NOTICE);
     sai_log_set(SAI_API_BRIDGE,                 SAI_LOG_LEVEL_NOTICE);
@@ -199,6 +201,7 @@ void initSaiApi()
     sai_log_set(SAI_API_SAMPLEPACKET,           SAI_LOG_LEVEL_NOTICE);
     sai_log_set(SAI_API_DEBUG_COUNTER,          SAI_LOG_LEVEL_NOTICE);
     sai_log_set((sai_api_t)SAI_API_NAT,         SAI_LOG_LEVEL_NOTICE);
+    sai_log_set(SAI_API_SYSTEM_PORT,            SAI_LOG_LEVEL_NOTICE);
 }
 
 void initSaiRedis(const string &record_location)

--- a/portsyncd/linksync.h
+++ b/portsyncd/linksync.h
@@ -21,6 +21,7 @@ public:
 private:
     ProducerStateTable m_portTableProducer;
     Table m_portTable, m_statePortTable, m_stateMgmtPortTable;
+    Table m_appSystemPortTable;
 
     std::map<unsigned int, std::string> m_ifindexNameMap;
     std::map<unsigned int, std::string> m_ifindexOldNameMap;

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -182,6 +182,7 @@ namespace aclorch_test
         shared_ptr<swss::DBConnector> m_app_db;
         shared_ptr<swss::DBConnector> m_config_db;
         shared_ptr<swss::DBConnector> m_state_db;
+        shared_ptr<swss::DBConnector> m_voq_db;
 
         AclOrchTest()
         {
@@ -189,6 +190,7 @@ namespace aclorch_test
             m_app_db = make_shared<swss::DBConnector>("APPL_DB", 0);
             m_config_db = make_shared<swss::DBConnector>("CONFIG_DB", 0);
             m_state_db = make_shared<swss::DBConnector>("STATE_DB", 0);
+            m_voq_db = make_shared<swss::DBConnector>("VOQ_DB", 0);
         }
 
         static map<string, string> gProfileMap;
@@ -307,10 +309,10 @@ namespace aclorch_test
             gVrfOrch = new VRFOrch(m_app_db.get(), APP_VRF_TABLE_NAME, m_state_db.get(), STATE_VRF_OBJECT_TABLE_NAME);
 
             ASSERT_EQ(gIntfsOrch, nullptr);
-            gIntfsOrch = new IntfsOrch(m_app_db.get(), APP_INTF_TABLE_NAME, gVrfOrch);
+            gIntfsOrch = new IntfsOrch(m_app_db.get(), APP_INTF_TABLE_NAME, gVrfOrch, m_voq_db.get());
 
             ASSERT_EQ(gNeighOrch, nullptr);
-            gNeighOrch = new NeighOrch(m_app_db.get(), APP_NEIGH_TABLE_NAME, gIntfsOrch);
+            gNeighOrch = new NeighOrch(m_app_db.get(), APP_NEIGH_TABLE_NAME, gIntfsOrch, m_voq_db.get());
 
             ASSERT_EQ(gRouteOrch, nullptr);
             gRouteOrch = new RouteOrch(m_app_db.get(), APP_ROUTE_TABLE_NAME, gNeighOrch, gIntfsOrch, gVrfOrch);

--- a/tests/mock_tests/database_config.json
+++ b/tests/mock_tests/database_config.json
@@ -4,6 +4,11 @@
             "hostname" : "127.0.0.1",
             "port" : 6379,
             "unix_socket_path" : "/var/run/redis/redis.sock"
+        },
+        "redis-voq":{
+            "hostname" : "10.0.0.16",
+            "port" : 6380,
+            "unix_socket_path" : "/var/run/redis/redis.sock"
         }
     },
     "DATABASES" : {
@@ -51,6 +56,11 @@
             "id" : 7,
             "separator": "|",
             "instance" : "redis"
+        },
+        "VOQ_DB" : {
+            "id" : 11,
+            "separator": ":",
+            "instance" : "redis-voq"
         }
     },
     "VERSION" : "1.0"

--- a/tests/mock_tests/database_config.json
+++ b/tests/mock_tests/database_config.json
@@ -6,9 +6,9 @@
             "unix_socket_path" : "/var/run/redis/redis.sock"
         },
         "redis-voq":{
-            "hostname" : "10.0.0.16",
+            "hostname" : "240.127.1.1",
             "port" : 6380,
-            "unix_socket_path" : "/var/run/redis/redis.sock"
+            "unix_socket_path" : "/var/run/redis/redis-voq.sock"
         }
     },
     "DATABASES" : {


### PR DESCRIPTION
This has changes in orchagent for system port implementation. Summary of changes in each component is given below.
orchagent: (1) main() changes to gather system ports config from config and create voq switch. (2) Connect to redis instance in control card for global voq db.
portsorch: voq system port initialization
intfmgrd: Changes to process voq inband interfaces config
intfmgr: doTask() to process voq inband interface
intfsorch: (1) To process system interface from global voq db (2) to process voq inband interface 
neighorch: (1) To process system neighbor from global voq db (2) Neighbor record for remote neighbors to take encap index

